### PR TITLE
add Perl 5.34.1 and 5.36.0

### DIFF
--- a/5.34.1/Dockerfile
+++ b/5.34.1/Dockerfile
@@ -1,0 +1,26 @@
+FROM httpd:2.4.52
+
+ARG PERL_VERSION=5.34.1
+
+ENV MOD_PERL_VERSION 2.0.12
+ENV PERL_VERSION $PERL_VERSION
+
+ENV PATH /opt/perl-$PERL_VERSION/bin:$PATH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt-get update && \
+    apt-get install -yq --no-install-recommends perl ca-certificates curl build-essential libapr1-dev libaprutil1-dev && \
+    curl -sfL https://raw.githubusercontent.com/tokuhirom/Perl-Build/master/perl-build | perl - $PERL_VERSION /opt/perl-$PERL_VERSION/ -Duseshrplib -j "$(nproc)" && \
+    curl -sfLO https://dlcdn.apache.org/perl/mod_perl-$MOD_PERL_VERSION.tar.gz && \
+    echo "f5b821b59b0fdc9670e46ed0fcf32d8911f25126189a8b68c1652f9221eee269 *mod_perl-$MOD_PERL_VERSION.tar.gz" | sha256sum -c && \
+    tar xzf mod_perl-$MOD_PERL_VERSION.tar.gz && \
+    cd mod_perl-$MOD_PERL_VERSION && \
+    /opt/perl-$PERL_VERSION/bin/perl Makefile.PL MP_NO_THREADS=1 && \
+    make -j "$(nproc)" && \
+    make install && \
+    cd .. && \
+    rm -rf mod_perl-$MOD_PERL_VERSION mod_perl-$MOD_PERL_VERSION.tar.gz && \
+    apt-get remove -yq perl ca-certificates curl build-essential && \
+    apt-get autoremove -yq && \
+    rm -rf /var/lib/apt/lists/*

--- a/5.36.0/Dockerfile
+++ b/5.36.0/Dockerfile
@@ -1,0 +1,26 @@
+FROM httpd:2.4.52
+
+ARG PERL_VERSION=5.36.0
+
+ENV MOD_PERL_VERSION 2.0.12
+ENV PERL_VERSION $PERL_VERSION
+
+ENV PATH /opt/perl-$PERL_VERSION/bin:$PATH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt-get update && \
+    apt-get install -yq --no-install-recommends perl ca-certificates curl build-essential libapr1-dev libaprutil1-dev && \
+    curl -sfL https://raw.githubusercontent.com/tokuhirom/Perl-Build/master/perl-build | perl - $PERL_VERSION /opt/perl-$PERL_VERSION/ -Duseshrplib -j "$(nproc)" && \
+    curl -sfLO https://dlcdn.apache.org/perl/mod_perl-$MOD_PERL_VERSION.tar.gz && \
+    echo "f5b821b59b0fdc9670e46ed0fcf32d8911f25126189a8b68c1652f9221eee269 *mod_perl-$MOD_PERL_VERSION.tar.gz" | sha256sum -c && \
+    tar xzf mod_perl-$MOD_PERL_VERSION.tar.gz && \
+    cd mod_perl-$MOD_PERL_VERSION && \
+    /opt/perl-$PERL_VERSION/bin/perl Makefile.PL MP_NO_THREADS=1 && \
+    make -j "$(nproc)" && \
+    make install && \
+    cd .. && \
+    rm -rf mod_perl-$MOD_PERL_VERSION mod_perl-$MOD_PERL_VERSION.tar.gz && \
+    apt-get remove -yq perl ca-certificates curl build-essential && \
+    apt-get autoremove -yq && \
+    rm -rf /var/lib/apt/lists/*

--- a/generate
+++ b/generate
@@ -10,6 +10,8 @@ perl_versions=(
     5.30.3
     5.32.1
     5.34.0
+    5.34.1
+    5.36.0
 )
 
 for perl_version in "${perl_versions[@]}"; do


### PR DESCRIPTION
<details>
<summary>5.34.1 run log</summary>

```
cohalz@co docker-mod_perl % docker run -it --rm 5.34.1-arm perl -v

This is perl 5, version 34, subversion 1 (v5.34.1) built for aarch64-linux

Copyright 1987-2022, Larry Wall

Perl may be copied only under the terms of either the Artistic License or the
GNU General Public License, which may be found in the Perl 5 source kit.

Complete documentation for Perl, including FAQ lists, should be found on
this system using "man perl" or "perldoc perl".  If you have access to the
Internet, point your browser at http://www.perl.org/, the Perl Home Page.

cohalz@co docker-mod_perl % docker run -it --rm 5.34.1-arm
AH00558: httpd: Could not reliably determine the server's fully qualified domain name, using 172.17.0.2. Set the 'ServerName' directive globally to suppress this message
AH00558: httpd: Could not reliably determine the server's fully qualified domain name, using 172.17.0.2. Set the 'ServerName' directive globally to suppress this message
[Fri Jul 29 01:56:38.241599 2022] [mpm_event:notice] [pid 1:tid 281473330053136] AH00489: Apache/2.4.52 (Unix) configured -- resuming normal operations
[Fri Jul 29 01:56:38.242088 2022] [core:notice] [pid 1:tid 281473330053136] AH00094: Command line: 'httpd -D FOREGROUND'
^C[Fri Jul 29 01:56:39.700078 2022] [mpm_event:notice] [pid 1:tid 281473330053136] AH00491: caught SIGTERM, shutting down
```
</details>

<details>
<summary>5.36.0 run log</summary>

```
cohalz@co docker-mod_perl % docker run -it --rm 5.36.0-arm perl -v

This is perl 5, version 36, subversion 0 (v5.36.0) built for aarch64-linux

Copyright 1987-2022, Larry Wall

Perl may be copied only under the terms of either the Artistic License or the
GNU General Public License, which may be found in the Perl 5 source kit.

Complete documentation for Perl, including FAQ lists, should be found on
this system using "man perl" or "perldoc perl".  If you have access to the
Internet, point your browser at https://www.perl.org/, the Perl Home Page.

cohalz@co docker-mod_perl % docker run -it --rm 5.36.0-arm
AH00558: httpd: Could not reliably determine the server's fully qualified domain name, using 172.17.0.2. Set the 'ServerName' directive globally to suppress this message
AH00558: httpd: Could not reliably determine the server's fully qualified domain name, using 172.17.0.2. Set the 'ServerName' directive globally to suppress this message
[Fri Jul 29 01:49:38.579427 2022] [mpm_event:notice] [pid 1:tid 281473810235408] AH00489: Apache/2.4.52 (Unix) configured -- resuming normal operations
[Fri Jul 29 01:49:38.579531 2022] [core:notice] [pid 1:tid 281473810235408] AH00094: Command line: 'httpd -D FOREGROUND'
^C[Fri Jul 29 01:49:42.222426 2022] [mpm_event:notice] [pid 1:tid 281473810235408] AH00491: caught SIGTERM, shutting down
```
</details>