### PR TITLE
Add 5.36.3 and 5.38.2

### DIFF
--- a/5.36.3/Dockerfile
+++ b/5.36.3/Dockerfile
@@ -1,0 +1,27 @@
+FROM httpd:2.4.58
+
+ARG PERL_VERSION=5.36.3
+
+ENV MOD_PERL_VERSION 2.0.13
+ENV MOD_PERL_CHECKSUM ade3be31c447b8448869fecdfcace258d6d587b8c6c773c5f22735f70d82d6da
+ENV PERL_VERSION $PERL_VERSION
+
+ENV PATH /opt/perl-$PERL_VERSION/bin:$PATH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt-get update && \
+    apt-get install -yq --no-install-recommends perl ca-certificates curl build-essential libapr1-dev libaprutil1-dev && \
+    curl -sfL https://raw.githubusercontent.com/tokuhirom/Perl-Build/master/perl-build | perl - $PERL_VERSION /opt/perl-$PERL_VERSION/ -Duseshrplib -j "$(nproc)" && \
+    curl -sfLO https://dlcdn.apache.org/perl/mod_perl-$MOD_PERL_VERSION.tar.gz && \
+    echo "$MOD_PERL_CHECKSUM *mod_perl-$MOD_PERL_VERSION.tar.gz" | sha256sum -c && \
+    tar xzf mod_perl-$MOD_PERL_VERSION.tar.gz && \
+    cd mod_perl-$MOD_PERL_VERSION && \
+    /opt/perl-$PERL_VERSION/bin/perl Makefile.PL MP_NO_THREADS=1 && \
+    make -j "$(nproc)" && \
+    make install && \
+    cd .. && \
+    rm -rf mod_perl-$MOD_PERL_VERSION mod_perl-$MOD_PERL_VERSION.tar.gz && \
+    apt-get remove -yq perl ca-certificates curl build-essential && \
+    apt-get autoremove -yq && \
+    rm -rf /var/lib/apt/lists/*

--- a/5.38.2/Dockerfile
+++ b/5.38.2/Dockerfile
@@ -1,0 +1,27 @@
+FROM httpd:2.4.58
+
+ARG PERL_VERSION=5.38.2
+
+ENV MOD_PERL_VERSION 2.0.13
+ENV MOD_PERL_CHECKSUM ade3be31c447b8448869fecdfcace258d6d587b8c6c773c5f22735f70d82d6da
+ENV PERL_VERSION $PERL_VERSION
+
+ENV PATH /opt/perl-$PERL_VERSION/bin:$PATH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt-get update && \
+    apt-get install -yq --no-install-recommends perl ca-certificates curl build-essential libapr1-dev libaprutil1-dev && \
+    curl -sfL https://raw.githubusercontent.com/tokuhirom/Perl-Build/master/perl-build | perl - $PERL_VERSION /opt/perl-$PERL_VERSION/ -Duseshrplib -j "$(nproc)" && \
+    curl -sfLO https://dlcdn.apache.org/perl/mod_perl-$MOD_PERL_VERSION.tar.gz && \
+    echo "$MOD_PERL_CHECKSUM *mod_perl-$MOD_PERL_VERSION.tar.gz" | sha256sum -c && \
+    tar xzf mod_perl-$MOD_PERL_VERSION.tar.gz && \
+    cd mod_perl-$MOD_PERL_VERSION && \
+    /opt/perl-$PERL_VERSION/bin/perl Makefile.PL MP_NO_THREADS=1 && \
+    make -j "$(nproc)" && \
+    make install && \
+    cd .. && \
+    rm -rf mod_perl-$MOD_PERL_VERSION mod_perl-$MOD_PERL_VERSION.tar.gz && \
+    apt-get remove -yq perl ca-certificates curl build-essential && \
+    apt-get autoremove -yq && \
+    rm -rf /var/lib/apt/lists/*

--- a/generate
+++ b/generate
@@ -12,7 +12,9 @@ perl_versions=(
     5.34.0
     5.34.1
     5.36.0
+    5.36.3
     5.38.0
+    5.38.2
 )
 
 for perl_version in "${perl_versions[@]}"; do


### PR DESCRIPTION
```
$ docker run -it --rm mod_perl-5.38.2 perl -v

This is perl 5, version 38, subversion 2 (v5.38.2) built for x86_64-linux

Copyright 1987-2023, Larry Wall

Perl may be copied only under the terms of either the Artistic License or the
GNU General Public License, which may be found in the Perl 5 source kit.

Complete documentation for Perl, including FAQ lists, should be found on
this system using "man perl" or "perldoc perl".  If you have access to the
Internet, point your browser at https://www.perl.org/, the Perl Home Page
```

```
$ docker run -it --rm mod_perl-5.36.3 perl -v

This is perl 5, version 36, subversion 3 (v5.36.3) built for x86_64-linux

Copyright 1987-2023, Larry Wall

Perl may be copied only under the terms of either the Artistic License or the
GNU General Public License, which may be found in the Perl 5 source kit.

Complete documentation for Perl, including FAQ lists, should be found on
this system using "man perl" or "perldoc perl".  If you have access to the
Internet, point your browser at https://www.perl.org/, the Perl Home Page.

```

Thanks :)